### PR TITLE
Implemented reading scripts from stdin

### DIFF
--- a/script.go
+++ b/script.go
@@ -24,18 +24,44 @@ type Script struct {
 	author   string
 	source   string
 	filename string
+	// piped if set signifies that the source is from stdin
+	piped bool
 }
 
 // NewScript copies the shell script specified in location (which may be local
 // or remote) to a temporary file and loads it into a Script.
-func NewScript(location string) (*Script, error) {
-	script := &Script{source: location}
-
+func NewScript(location string) (script *Script, err error) {
 	body, err := getFile(location)
 	if err != nil {
 		return nil, err
 	}
 	defer body.Close()
+
+	script, err = fnewScript(body)
+	if err != nil {
+		return
+	}
+
+	script.source = location
+	return
+}
+
+func FNewScript(r io.Reader) (script *Script, err error) {
+	script, err = fnewScript(r)
+	if err != nil {
+		return
+	}
+	script.piped = true
+	return
+}
+
+func fnewScript(r io.Reader) (*Script, error) {
+	// TODO: Detect if a reader is pipe-like
+	// ie like a named piped that could infinitely
+	// hang if content isn't read from it.
+	if r == nil {
+		return nil, fmt.Errorf("script body is nil")
+	}
 
 	file, err := ioutil.TempFile("", "pipethis-")
 	if err != nil {
@@ -43,8 +69,14 @@ func NewScript(location string) (*Script, error) {
 	}
 	defer file.Close()
 
-	io.Copy(file, body)
-	script.filename = file.Name()
+	n, err := io.Copy(file, r)
+	if n < 1 && err != nil {
+		return nil, err
+	}
+
+	script := &Script{
+		filename: file.Name(),
+	}
 
 	return script, nil
 }
@@ -119,4 +151,9 @@ func (s Script) Inspect(inspect bool, editor string) bool {
 	fmt.Scanf("%s", &runScript)
 
 	return strings.ToLower(runScript) == "y"
+}
+
+// Piped tells if a script was passed in from stdin
+func (s Script) Piped() bool {
+	return s.piped
 }

--- a/script_test.go
+++ b/script_test.go
@@ -9,6 +9,7 @@ the source. If not, see http://www.gnu.org/licenses/gpl-2.0.html.
 package main
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -54,6 +55,25 @@ func TestAuthorParsesFileForPattern(t *testing.T) {
 	os.Remove(filename)
 
 }
+
+func TestPipedScripts(t *testing.T) {
+	pr, pw := io.Pipe()
+	go func() {
+		defer pw.Close()
+		io.WriteString(pw, "echo $HOME")
+	}()
+
+	script, err := FNewScript(pr)
+	assert.NoError(t, err)
+
+	if script == nil {
+		assert.Fail(t, "script was parsed successfully but is nil")
+	}
+	if !script.Piped() {
+		assert.Fail(t, "script was piped so .Piped() should return true")
+	}
+}
+
 func providerTestAuthorInvalid() [][]string {
 	return [][]string{
 		[]string{"", ``},


### PR DESCRIPTION
Fixes #1.

This PR starts the ability to read from stdin.
The main problem though is that os.Stdin is consumed
for the script body's read and EOF encountered.
This means that we won't have interactive input.

Just to let you know there is a method script.Piped() that could potentially be useful in handling the non-interactiveness after EOF on stdin is encountered.

It is currently a work in progress so that I don't forget about it. Please feel free to copy the code, discard it or modify it.

Cheers!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ellotheth/pipethis/6)
<!-- Reviewable:end -->
