### PR TITLE
Read shell scripts from STDIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ improve your life)
 $ pipethis --no-verify --inspect https://get.rvm.io
 ```
 
+or even
+
+```
+$ curl -sSL https://get.rvm.io | pipethis --no-verify | bash
+```
+
+
 ## Install
 
 ```
@@ -59,9 +66,13 @@ OPTIONS
     local
         Use your local GnuPG public keyring
 
+    If you're piping a script from `stdin`, the service will be forced to
+    `local`.
+
 --inspect
 
-    If set, open the script in an editor before checking the author.
+    If set, open the script in an editor before checking the author. Ignored if
+    you're piping a script from `stdin`.
 
 --editor <editor>
 
@@ -75,10 +86,19 @@ OPTIONS
 
 --signature <signature file>
 
-	The detached signature to verify <script> against. You'll only need this if
-	you've already downloaded the detached signature, or it's hosted in a
-	non-standard location (i.e. it's not <script>.sig).
+	The detached signature to verify <script> against. You'll only need this in
+    a couple scenarios:
+
+    - You've already downloaded the detached signature and you want to use your
+      downloaded copy, or
+    - the signature is hosted in a non-standard location (i.e. it's not
+      <script>.sig), or
+    - you're piping a script with a detached signature from `stdin`.
 ```
+
+If you're piping scripts into `pipethis` directly from `curl`, you'll need
+to have the script authors' PGP keys already stored in your local keyring.
+Don't worry, they'll have instructions!
 
 ### People writing the installers
 
@@ -99,7 +119,7 @@ but there's other stuff to do as well:
     # // ; '' PIPETHIS_AUTHOR your_name_or_your_key_fingerprint
     ```
 
-3. Create a detached signature for the script. With Keybase, that's:
+3. Create a signature for the script. With Keybase, that's:
 
     ```
     $ keybase pgp sign -i yourscript.sh -d -o yourscript.sh.sig
@@ -111,9 +131,20 @@ but there's other stuff to do as well:
     $ gpg --detach-sign -a -o yourscript.sh.sig yourscript.sh
     ```
 
-	Both those commands create ASCII-armored signatures. Binary signatures work
-	too.
-4. Pop both the script and the signature up on your web server.
+   Both those commands create ASCII-armored signatures. Binary signatures work
+   too.
+
+   Alternatively, you can clearsign the script with an attached signature::
+
+    ```
+    $ keybase pgp sign -i yourscript.unsigned.sh -c -o yourscript.sh
+    ```
+
+    ```
+    $ gpg --clearsign -a -o yourscript.sh yourscript.unsigned.sh
+    ```
+
+4. Pop the script (and the signature, if it's detached) up on your web server.
 5. Replace your copy-paste-able installation instructions!
 
 ## What's all this noise
@@ -225,8 +256,6 @@ that you almost pwned yourself.
 
 `pipethis` works, but it can be better!
 
-- If there were a non-interactive version, it could be inserted into a pipe
-  chain like `curl -Ss http://pwn.me/please | pipethis | bash`. That'd be cool.
 - There are zillions of other places to get public keys for people, and I want
   to support more of them. I think Keybase is stellar and I love what they're
   trying to do, but nobody likes to be locked in to one provider.

--- a/lookup/lookup.go
+++ b/lookup/lookup.go
@@ -139,6 +139,10 @@ func Key(service KeyService, query string, single bool) (openpgp.KeyRing, error)
 		return nil, err
 	}
 
+	if len(matches) < 1 {
+		return nil, errors.New("No author matches found for " + query)
+	}
+
 	// verify that the author is who the user was expecting by showing all the
 	// details (twitter handle, github handle, websites, etc.)
 	var match User

--- a/lookup/lookup.go
+++ b/lookup/lookup.go
@@ -157,7 +157,7 @@ func Key(service KeyService, query string, single bool) (openpgp.KeyRing, error)
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("Using %v (%v)", match.Username, ring[0].PrimaryKey.KeyIdShortString())
+	log.Printf("Verifying your script against\n%v", match)
 
 	return ring, nil
 }

--- a/lookup/lookup.go
+++ b/lookup/lookup.go
@@ -69,6 +69,24 @@ func (u User) String() string {
 	return s
 }
 
+// NewKeyService creates the KeyService implementation requested by name. If
+// fromPipe is true, it creates a LocalPGPService type.
+func NewKeyService(name string, fromPipe bool) (KeyService, error) {
+	// force the local keyring when reading the script from a pipe
+	if fromPipe {
+		name = "local"
+	}
+
+	switch name {
+	case "keybase":
+		return &KeybaseService{}, nil
+	case "local":
+		return NewLocalPGPService()
+	}
+
+	return nil, errors.New("Unrecognized key service")
+}
+
 // chooseMatch prints all the matches provided, prompts for a choice, and
 // returns the chosen match.
 func chooseMatch(matches []User) (User, error) {

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -1,0 +1,72 @@
+/*
+pipethis: Stop piping the internet into your shell
+Copyright 2016 Ellotheth
+
+Use of this source code is governed by the GNU Public License version 2
+(GPLv2). You should have received a copy of the GPLv2 along with your copy of
+the source. If not, see http://www.gnu.org/licenses/gpl-2.0.html.
+*/
+
+package lookup
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type LookupTest struct {
+	home string
+	suite.Suite
+}
+
+func (s *LookupTest) SetupSuite() {
+	s.home = os.Getenv("HOME")
+	os.Setenv("HOME", os.TempDir())
+}
+
+func (s *LookupTest) TeardownSuite() {
+	os.Setenv("HOME", s.home)
+}
+
+func (s *LookupTest) TestNewKeyServiceAcceptsKeybaseWithoutPipe() {
+	service, err := NewKeyService("keybase", false)
+
+	s.NoError(err)
+	s.IsType(&KeybaseService{}, service)
+}
+
+func (s *LookupTest) TestNewKeyServiceForcesLocalWithPipe() {
+	_, err := NewKeyService("keybase", true)
+	s.Error(err)
+
+	perr, ok := err.(*os.PathError)
+	s.True(ok)
+	s.Equal("/tmp/.gnupg/pubring.gpg", perr.Path)
+}
+
+func (s *LookupTest) TestChooseSingleMatchBailsWithoutMatches() {
+	user, err := chooseSingleMatch([]User{})
+
+	s.Error(err)
+	s.Equal(User{}, user)
+}
+
+func (s *LookupTest) TestChooseSingleMatchBailsWithMoreThanOneMatch() {
+	user, err := chooseSingleMatch([]User{User{}, User{}})
+
+	s.Error(err)
+	s.Equal(User{}, user)
+}
+
+func (s *LookupTest) TestChooseSingleMatchReturnsSingleMatch() {
+	user, err := chooseSingleMatch([]User{User{Username: "foo"}})
+
+	s.NoError(err)
+	s.Equal("foo", user.Username)
+}
+
+func TestLookupTest(t *testing.T) {
+	suite.Run(t, new(LookupTest))
+}

--- a/main.go
+++ b/main.go
@@ -86,8 +86,7 @@ func main() {
 			log.Panic(err)
 		}
 
-		// todo this needs to only return one match for piped input
-		key, err := lookup.Key(service, author)
+		key, err := lookup.Key(service, author, script.IsPiped())
 		if err != nil {
 			log.Panic(err)
 		}

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func main() {
 			log.Panic(err)
 		}
 
-		log.Println("Signature", signature.Source(), "verified!")
+		log.Println("Signature verified!")
 	}
 
 	// run the script

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 			log.Panic(err)
 		}
 
-		service, err := makeService(*serviceName, script.IsPiped())
+		service, err := lookup.NewKeyService(*serviceName, script.IsPiped())
 		if err != nil {
 			log.Panic(err)
 		}
@@ -173,20 +173,4 @@ func getLocal(location string) (io.ReadCloser, error) {
 	}
 
 	return os.Open(location)
-}
-
-func makeService(name string, fromPipe bool) (lookup.KeyService, error) {
-	// force the local keyring when reading the script from a pipe
-	if fromPipe {
-		name = "local"
-	}
-
-	switch name {
-	case "keybase":
-		return &lookup.KeybaseService{}, nil
-	case "local":
-		return lookup.NewLocalPGPService()
-	}
-
-	return nil, errors.New("Unrecognized key service")
 }

--- a/main.go
+++ b/main.go
@@ -81,8 +81,7 @@ func main() {
 			log.Panic(err)
 		}
 
-		// todo force local keyring for piped input
-		service, err := makeService(*serviceName)
+		service, err := makeService(*serviceName, script.IsPiped())
 		if err != nil {
 			log.Panic(err)
 		}
@@ -184,7 +183,12 @@ func getLocal(location string) (io.ReadCloser, error) {
 	return os.Open(location)
 }
 
-func makeService(name string) (lookup.KeyService, error) {
+func makeService(name string, fromPipe bool) (lookup.KeyService, error) {
+	// force the local keyring when reading the script from a pipe
+	if fromPipe {
+		name = "local"
+	}
+
 	switch name {
 	case "keybase":
 		return &lookup.KeybaseService{}, nil

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 	// still happen.
 	defer func() {
 		if r := recover(); r != nil {
+			flag.Usage()
 			os.Exit(1)
 		}
 	}()
@@ -150,7 +151,7 @@ func getFromStdin() (io.ReadCloser, error) {
 
 	// could also use os.ModeNamedPipe here? not sure if the difference matters
 	if (stat.Mode() & os.ModeCharDevice) != 0 {
-		return nil, errors.New("No data in STDIN")
+		return nil, errors.New("Nothing to read from STDIN and no script given")
 	}
 
 	return os.Stdin, nil

--- a/main.go
+++ b/main.go
@@ -103,9 +103,12 @@ func main() {
 
 	// run the script
 	if script.IsPiped() {
-		script.Echo()
+		err = script.Echo()
 	} else {
-		script.Run(*target, flag.Args()...)
+		err = script.Run(*target, flag.Args()...)
+	}
+	if err != nil {
+		log.Panic(err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -145,19 +145,12 @@ func getFromStdin() (io.ReadCloser, error) {
 		return nil, err
 	}
 
+	// could also use os.ModeNamedPipe here? not sure if the difference matters
 	if (stat.Mode() & os.ModeCharDevice) != 0 {
 		return nil, errors.New("No data in STDIN")
 	}
 
 	return os.Stdin, nil
-	// return ioutil.NopCloser(bufio.NewReader(os.Stdin)), nil
-
-	// body, err := ioutil.ReadAll(os.Stdin)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// return ioutil.NopCloser(bytes.NewReader(body)), nil
 }
 
 func getRemote(location string) (io.ReadCloser, error) {

--- a/script.go
+++ b/script.go
@@ -102,6 +102,8 @@ func (s *Script) detachSignature(contents []byte) ([]byte, error) {
 	return contents, nil
 }
 
+// IsPiped is true when the script was read from STDIN (so the source location
+// is empty)
 func (s Script) IsPiped() bool {
 	return s.source == ""
 }
@@ -159,6 +161,7 @@ func (s Script) Run(target string, args ...string) error {
 	return cmd.Run()
 }
 
+// Echo prints the contents of the script to STDOUT
 func (s Script) Echo() {
 	log.Println("Sending", s.Name(), "to STDOUT for more processing")
 	body, _ := s.Body()

--- a/script.go
+++ b/script.go
@@ -97,7 +97,11 @@ func (s *Script) detachSignature(contents []byte) ([]byte, error) {
 		return nil, err
 	}
 	defer sigWriter.Close()
-	io.Copy(sigWriter, block.ArmoredSignature.Body)
+
+	_, err = io.Copy(sigWriter, block.ArmoredSignature.Body)
+	if err != nil {
+		return nil, err
+	}
 
 	return contents, nil
 }
@@ -162,12 +166,21 @@ func (s Script) Run(target string, args ...string) error {
 }
 
 // Echo prints the contents of the script to STDOUT
-func (s Script) Echo() {
+func (s Script) Echo() error {
 	log.Println("Sending", s.Name(), "to STDOUT for more processing")
-	body, _ := s.Body()
+
+	body, err := s.Body()
+	if err != nil {
+		return err
+	}
 	defer body.Close()
 
-	io.Copy(os.Stdout, body)
+	_, err = io.Copy(os.Stdout, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Inspect checks whether an inspection was requested, and sends Script.Name()

--- a/script.go
+++ b/script.go
@@ -149,11 +149,9 @@ func (s *Script) Author() (string, error) {
 func (s Script) Run(target string, args ...string) error {
 	log.Println("Running", s.Name(), "with", target)
 
-	if s.source == "" {
-		args = append([]string{s.Name()}, args...)
-	} else {
-		args[0] = s.Name()
-	}
+	// the first argument is the script source location. replace it with the
+	// temporary filename.
+	args[0] = s.Name()
 
 	cmd := exec.Command(target, args...)
 	cmd.Stdout = os.Stdout

--- a/script.go
+++ b/script.go
@@ -143,7 +143,11 @@ func (s *Script) Author() (string, error) {
 // additional arguments from the command line. It returns the result of the
 // process.
 func (s Script) Run(target string, args ...string) error {
-	args[0] = s.Name()
+	if s.source == "" {
+		args = append([]string{s.Name()}, args...)
+	} else {
+		args[0] = s.Name()
+	}
 
 	cmd := exec.Command(target, args...)
 	cmd.Stdout = os.Stdout

--- a/script.go
+++ b/script.go
@@ -205,3 +205,9 @@ func (s Script) Inspect(inspect bool, editor string) bool {
 
 	return strings.ToLower(runScript) == "y"
 }
+
+// IsClearsigned returns true if the script and signature are attached,
+// and false otherwise.
+func (s Script) IsClearsigned() bool {
+	return s.clearsigned
+}

--- a/signature.go
+++ b/signature.go
@@ -74,7 +74,10 @@ func (s *Signature) Download() error {
 	}
 	defer file.Close()
 
-	io.Copy(file, body)
+	_, err = io.Copy(file, body)
+	if err != nil {
+		return nil
+	}
 
 	return nil
 }


### PR DESCRIPTION
Accept a script from `STDIN`. Reading from a pipe kills the interactive options (because it eats `STDIN`), so the behavior is different:

- `--inspect` is ignored.
- `--target` is ignored. Instead of running the script, `pipethis` will echo the contents to `STDOUT` (so it can be piped to the target executable, e.g. `curl | pipethis | sh` ).
- Author matches must come from the user's local PGP keyring.
- The author must match exactly one identity in the keyring.
- The author match will be automatically selected, without input from the user.

Fixes #1. See also #6.