### PR TITLE
Support GNUPGHOME environment variable

### DIFF
--- a/lookup/localpgp.go
+++ b/lookup/localpgp.go
@@ -30,14 +30,14 @@ type LocalPGPService struct {
 // public keyring; otherwise it bails.
 func NewLocalPGPService() (*LocalPGPService, error) {
 
-	home := os.Getenv("HOME")
+	gnupgHome := path.Join(os.Getenv("HOME"), ".gnupg")
 
 	// Check if an override for GNUPG home is set
 	if os.Getenv("GNUPGHOME") != "" {
-		home = os.Getenv("GNUPGHOME")
+		gnupgHome = os.Getenv("GNUPGHOME")
 	}
 
-	ringfile := path.Join(home, ".gnupg", "pubring.gpg")
+	ringfile := path.Join(gnupgHome, "pubring.gpg")
 
 	info, err := os.Stat(ringfile)
 	if err != nil || info.Size() == 0 {

--- a/lookup/localpgp.go
+++ b/lookup/localpgp.go
@@ -29,7 +29,15 @@ type LocalPGPService struct {
 // NewLocalPGPService creates a new LocalPGPService if it finds a local
 // public keyring; otherwise it bails.
 func NewLocalPGPService() (*LocalPGPService, error) {
-	ringfile := path.Join(os.Getenv("HOME"), ".gnupg", "pubring.gpg")
+
+	home := os.Getenv("HOME")
+
+	// Check if an override for GNUPG home is set
+	if os.Getenv("GNUPGHOME") != "" {
+		home = os.Getenv("GNUPGHOME")
+	}
+
+	ringfile := path.Join(home, ".gnupg", "pubring.gpg")
 
 	info, err := os.Stat(ringfile)
 	if err != nil || info.Size() == 0 {

--- a/lookup/localpgp.go
+++ b/lookup/localpgp.go
@@ -30,6 +30,18 @@ type LocalPGPService struct {
 // public keyring; otherwise it bails.
 func NewLocalPGPService() (*LocalPGPService, error) {
 
+	service := &LocalPGPService{}
+	service.buildRingfileName()
+
+	info, err := os.Stat(service.ringfile)
+	if err != nil || info.Size() == 0 {
+		return nil, err
+	}
+
+	return service, nil
+}
+
+func (l *LocalPGPService) buildRingfileName() {
 	gnupgHome := path.Join(os.Getenv("HOME"), ".gnupg")
 
 	// Check if an override for GNUPG home is set
@@ -37,14 +49,7 @@ func NewLocalPGPService() (*LocalPGPService, error) {
 		gnupgHome = os.Getenv("GNUPGHOME")
 	}
 
-	ringfile := path.Join(gnupgHome, "pubring.gpg")
-
-	info, err := os.Stat(ringfile)
-	if err != nil || info.Size() == 0 {
-		return nil, err
-	}
-
-	return &LocalPGPService{ringfile: ringfile}, nil
+	l.ringfile = path.Join(gnupgHome, "pubring.gpg")
 }
 
 // Ring loads the local public keyring so LocalPGPService can use it later. If

--- a/lookup/localpgp_test.go
+++ b/lookup/localpgp_test.go
@@ -10,9 +10,9 @@ the source. If not, see http://www.gnu.org/licenses/gpl-2.0.html.
 package lookup
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/suite"
+	"os"
+	"testing"
 )
 
 type LocalPGPTest struct {
@@ -46,6 +46,13 @@ func (s *LocalPGPTest) TestIsMatchFailsWithoutMatches() {
 	user := User{}
 
 	s.False(local.isMatch("foo", user))
+}
+
+func (s *LocalPGPTest) TestGnupgHomeOverride() {
+	os.Setenv("GNUPGHOME", "/foo")
+	_, err := NewLocalPGPService()
+	s.True(err.Error() == "stat /foo/pubring.gpg: no such file or directory")
+	os.Unsetenv("GNUPGHOME")
 }
 
 func TestLocalPGPTest(t *testing.T) {

--- a/lookup/localpgp_test.go
+++ b/lookup/localpgp_test.go
@@ -10,9 +10,10 @@ the source. If not, see http://www.gnu.org/licenses/gpl-2.0.html.
 package lookup
 
 import (
-	"github.com/stretchr/testify/suite"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type LocalPGPTest struct {
@@ -51,8 +52,33 @@ func (s *LocalPGPTest) TestIsMatchFailsWithoutMatches() {
 func (s *LocalPGPTest) TestGnupgHomeOverride() {
 	os.Setenv("GNUPGHOME", "/foo")
 	_, err := NewLocalPGPService()
-	s.True(err.Error() == "stat /foo/pubring.gpg: no such file or directory")
+	s.EqualError(err, "stat /foo/pubring.gpg: no such file or directory")
 	os.Unsetenv("GNUPGHOME")
+}
+
+func (s *LocalPGPTest) TestBuildRingfileName() {
+	cases := []struct {
+		home      string
+		gnupghome string
+		expected  string
+	}{
+		{"/foo/", "", "/foo/.gnupg/pubring.gpg"},
+		{"/foo", "", "/foo/.gnupg/pubring.gpg"},
+		{"foo", "", "foo/.gnupg/pubring.gpg"},
+		{"foo", "/things", "/things/pubring.gpg"},
+		{"foo", "/things/", "/things/pubring.gpg"},
+		{"foo", "things/", "things/pubring.gpg"},
+		{"", "/things/", "/things/pubring.gpg"},
+		{"", "", ".gnupg/pubring.gpg"},
+	}
+
+	for _, c := range cases {
+		os.Setenv("HOME", c.home)
+		os.Setenv("GNUPGHOME", c.gnupghome)
+		local := LocalPGPService{}
+		local.buildRingfileName()
+		s.Equal(c.expected, local.ringfile)
+	}
 }
 
 func TestLocalPGPTest(t *testing.T) {


### PR DESCRIPTION
I sometimes use the `GNUPGHOME` variable to point to a different set of rings.

This pull request should enable the usage of the environment variable and perform the previous behaviour if it is not set.
Let me know what you think.