### PR TITLE
Fix hardcoded path to temp folder in test to be determined by the OS

### DIFF
--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -43,7 +43,7 @@ func (s *LookupTest) TestNewKeyServiceForcesLocalWithPipe() {
 
 	perr, ok := err.(*os.PathError)
 	s.True(ok)
-	s.Equal("/tmp/.gnupg/pubring.gpg", perr.Path)
+	s.Equal(os.Getenv("HOME")+".gnupg/pubring.gpg", perr.Path)
 }
 
 func (s *LookupTest) TestChooseSingleMatchBailsWithoutMatches() {

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -11,6 +11,7 @@ package lookup
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -23,7 +24,7 @@ type LookupTest struct {
 
 func (s *LookupTest) SetupSuite() {
 	s.home = os.Getenv("HOME")
-	os.Setenv("HOME", os.TempDir())
+	os.Setenv("HOME", strings.TrimRight(os.TempDir(), "/"))
 }
 
 func (s *LookupTest) TeardownSuite() {
@@ -43,7 +44,7 @@ func (s *LookupTest) TestNewKeyServiceForcesLocalWithPipe() {
 
 	perr, ok := err.(*os.PathError)
 	s.True(ok)
-	s.Equal(os.Getenv("HOME")+".gnupg/pubring.gpg", perr.Path)
+	s.Equal(os.Getenv("HOME")+"/.gnupg/pubring.gpg", perr.Path)
 }
 
 func (s *LookupTest) TestChooseSingleMatchBailsWithoutMatches() {


### PR DESCRIPTION
I was trying to run the test suite on OSX and came across this hardcoded reference to `/tmp`.
On OSX, the temp folder is a random folder inside `/var/folders` for some reason, and it's making the test fail.
Changed the equality check to reference the HOME environment variable.

Example:
```
$ echo $TMPDIR
/var/folders/11/zjs4tmks4kt5lt6wy6t8n00000cn/T/
```