### PR TITLE
Add Install information when using homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,22 @@ $ curl -sSL https://get.rvm.io | pipethis --no-verify | bash
 
 ## Install
 
+### Golang
+
 ```
 $ go get github.com/ellotheth/pipethis
 ```
 
-or [download the binary](https://github.com/ellotheth/pipethis/releases) and
-drop it in your `$PATH`.
+### MacOSX
+
+```
+$ brew tap dennisdegreef/pipethis
+$ brew install pipethis
+```
+
+### Manual
+
+[download the binary](https://github.com/ellotheth/pipethis/releases) and drop it in your `$PATH`.
 
 ## Use
 


### PR DESCRIPTION
Related to #11 and #12 

If you want to have this [Homebrew tap](https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/How-to-Create-and-Maintain-a-Tap.md) under your own name (people might recognise the repo, and trust it more if the author is the same?), please [clone](https://github.com/dennisdegreef/homebrew-pipethis.git) the repo and push it to your own, replacing the name in this PR, and that should be it :+1:

Easy installation for MacOSX users using the Homebrew package manager.
